### PR TITLE
removed the semi-colons in the color object example

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,18 +177,18 @@ It's a nice key!
   <p>Use dot-notation to create nested objects.</p>
 
 <aml>
-colors.red: #f00;
-colors.green: #0f0;
-colors.blue: #00f;
+colors.red: #f00
+colors.green: #0f0
+colors.blue: #00f
 </aml>
 
   <p>You can also use "object" blocks to namespace a group of keys.</p>
 
 <aml>
 {colors}
-red: #f00;
-green: #0f0;
-blue: #00f;
+red: #f00
+green: #0f0
+blue: #00f
 
 {numbers}
 one: 1
@@ -205,12 +205,12 @@ key: value
 
 <aml>
 {colors.reds}
-crimson: #dc143c;
-darkred: #8b0000;
+crimson: #dc143c
+darkred: #8b0000
 
 {colors.blues}
-cornflowerblue: #6495ed;
-darkblue: #00008b;
+cornflowerblue: #6495ed
+darkblue: #00008b
 </aml>
 
   <h3>Arrays of objects</h3>


### PR DESCRIPTION
I think the semi-colons were only confusing the examples, but feel free to reject the PR
