### PR TITLE
Change order of result in nested arrays test #5

### DIFF
--- a/test/1.0/arrays_nested.5.aml
+++ b/test/1.0/arrays_nested.5.aml
@@ -1,5 +1,5 @@
 test: subarrays can be closed to return to the parent level
-result: {"array": [{"parentkey": "value", "subarray": [{"subkey": "value"}]}]}
+result: {"array": [{"subarray": [{"subkey": "value"}], "parentkey": "value"}]}
 
 [array]
 [.subarray]


### PR DESCRIPTION
The previous iteration of this test returned a result with a different order than the test value.  This may not matter for cases where the order of the object doesn't matter, but in my case (converting the JSON to R), order always matters.
